### PR TITLE
Replaced path.exists with fs.exists

### DIFF
--- a/lib/walt.js
+++ b/lib/walt.js
@@ -352,7 +352,7 @@
 
                 curr = parts.slice(0, pos + 1).join(self.separator());
 
-                path.exists(curr, function (exists) {
+                fs.exists(curr, function (exists) {
                     if (!exists) {
                         fs.mkdir(curr, function () {
                             mkdir(++pos);
@@ -448,7 +448,7 @@
 
             loc = path.normalize(locations[i]);
 
-            path.exists(loc, function (exists) {
+            fs.exists(loc, function (exists) {
                 if (!exists) {
                     get(++i);
                     return;


### PR DESCRIPTION
path.exists has been depracted since around node 0.10.0 and was failing with node 0.12.0+